### PR TITLE
Hotfixing Content Uploading

### DIFF
--- a/business/content_handler.js
+++ b/business/content_handler.js
@@ -53,57 +53,67 @@ function uploadContent(formRequest)
         const fileParser = new formidable.IncomingForm();
 
         fileParser.parse(formRequest)
-            .on('fileBegin', async (name, file) => {
-                var uploadFolder = __dirname + '/uploads/';
-                var expectedTempFileLocation = uploadFolder + file.name;
+        .on('file', async (name, file) => {
+            const contentUrl = file.path;
+            const contentType = file.type;
+            const externalPath = process.env.SFTP_UPLOAD_PATH + '\\' + file.name;
 
-                // If folder doesn't exist, create folder
-                await fs.stat(uploadFolder)
-                .catch(async (err) => 
-                    await fs.mkdir(uploadFolder)
-                );
+            var connectedClient;
 
-                file.path = expectedTempFileLocation;
-            })
-            .on('file', async (name, file) => {
-                const contentUrl = file.path;
-                const contentType = file.type;
-                const externalPath = process.env.SFTP_UPLOAD_PATH + '\\' + file.name;
+            try
+            {
+                connectedClient = await sftp_connector.getConnectedClient();
 
-                try {
-                    var connectedClient = await sftp_connector.getConnectedClient();
+                var fileExists = await connectedClient.exists(externalPath);
 
-                    await connectedClient.fastPut(contentUrl, externalPath);
-
-                    await this.createContent(externalPath, contentType);
-
-                    await connectedClient.end();
-
-                    resolve();
-                } catch(err) {
-                    reject(err);
+                // fileExists can be false, d (dir), - (file), or l (link).
+                // https://www.npmjs.com/package/ssh2-sftp-client#org62ac504
+                if(fileExists != false)
+                {
+                    throw new Error('File has already been uploaded, please upload something else.');
                 }
 
-                fs.unlink(contentUrl)
-                .then(() => {
-                    resolve();
-                })
-                .catch((err) => reject(err));
-            })
-            .on('error', (err) => {
+                await connectedClient.fastPut(contentUrl, externalPath);
+
+                await this.createContent(externalPath, contentType);
+
+                resolve();
+            }
+            catch(err)
+            {
                 reject(err);
-            })
+            }
+            finally
+            {
+                await connectedClient.end();
+
+                await fs.unlink(contentUrl);
+            }
+        })
+        .on('error', (err) => {
+            reject(err);
+        })
     })
 }
 
 function deleteContent(contentId, contentUrl) {
     return new Promise(async (resolve, reject) => 
     {
+        var connectedClient;
+
         try
         {
-            var connectedClient = await sftp_connector.getConnectedClient();
+            connectedClient = await sftp_connector.getConnectedClient();
 
-            await connectedClient.delete(contentUrl);
+            var fileExists = await connectedClient.exists(contentUrl);
+
+            // fileExists can be false, d (dir), - (file), or l (link).
+            // https://www.npmjs.com/package/ssh2-sftp-client#org62ac504
+            if(fileExists == '-')
+            {
+                await connectedClient.delete(contentUrl);
+            }
+            
             await database_connector.query('DELETE FROM content WHERE id = $1::integer', [contentId]);
 
             resolve();
@@ -111,6 +121,10 @@ function deleteContent(contentId, contentUrl) {
         catch(err)
         {
             reject(err);
+        }
+        finally
+        {
+            await connectedClient.end();
         }
     })
 }

--- a/data/sftp_connector.js
+++ b/data/sftp_connector.js
@@ -28,12 +28,22 @@ function getConnectionStatus()
 {
     // It resolves false instead of rejecting, this is so routes/status.js can easily render the status
     return new Promise((resolve, reject) => {
-        sftp_client.cwd()
-        .then(async (directory) => {
-            resolve(true);
+        sftp_client.connect(sftp_config)
+        .then(async () => {
+            var currentDirectory = await sftp_client.cwd();
+            
+            if(currentDirectory != null)
+            {
+                resolve(true);
+            }
+
+            resolve(false);
         })
         .catch(error => {
-            resolve(false);
+            reject(error);
+        })
+        .finally(async () => {
+            await sftp_client.end();
         })
     })
 }

--- a/routes/content.js
+++ b/routes/content.js
@@ -35,21 +35,25 @@ router.post('/', passport.authenticate('jwt', { session: false }), async functio
         contentType
     } = req.body;
 
-    await content_handler.createContent(contentUrl, contentType).catch((err) => {
+    content_handler.createContent(contentUrl, contentType)
+    .then(() => {
+        res.redirect('/content');
+    })
+    .catch((err) => {
         return next(new Error('Something went wrong creating a new content row, please try again.'));
     });
-
-    res.redirect('/content');
 })
 
 router.post('/upload', passport.authenticate('jwt', { session: false }), async function (req, res, next) {
     const formRequest = req;
 
-    await content_handler.uploadContent(formRequest).catch((err) => {
-        return next(new Error('Something went wrong uploading the content, check the database/file server status and try again.'));
+    content_handler.uploadContent(formRequest)
+    .then(() => {
+        res.redirect('/content');
     })
-
-    res.sendStatus(200);
+    .catch((err) => {
+        return next(new Error('Something went wrong uploading the content. Check the database/file server status and/or if the file hasn\'t been uploaded yet.'));
+    });
 })
 
 router.put('/', passport.authenticate('jwt', { session: false }), async function (req, res, next) {
@@ -59,11 +63,13 @@ router.put('/', passport.authenticate('jwt', { session: false }), async function
         contentType
     } = req.body;
 
-    await content_handler.updateContent(contentUrl, contentType, contentId).catch((err) => {
+    content_handler.updateContent(contentUrl, contentType, contentId)
+    .then(() => {
+        res.redirect('/content');
+    })
+    .catch((err) => {
         return next(new Error('Something went wrong updating the content, please try again.'));
     });
-
-    res.sendStatus(200);
 })
 
 router.delete('/', passport.authenticate('jwt', { session: false }), async function (req, res, next) {
@@ -72,16 +78,15 @@ router.delete('/', passport.authenticate('jwt', { session: false }), async funct
         contentUrl
     } = req.body;
 
-    try 
-    {
-        await content_handler.deleteContent(contentId, contentUrl);
-    } 
-    catch(err) 
+    content_handler.deleteContent(contentId, contentUrl)
+    .then(() => {
+        // Deleting content is done with an ajax call, thats why 200 is sent instead of redirecting to content.
+        res.sendStatus(200);
+    })
+    .catch((err) => 
     {
         return next(new Error('Something went wrong deleting the file, check the database/file server status and try again.'));
-    }
-
-    res.sendStatus(200);
+    });
 })
 
 module.exports = router;


### PR DESCRIPTION
-- Fixed SFTP server status not actually working. Connecting to it is needed, which may result in slower status page loading.

-- Content route now uses the promises the right way. Error handling and page refreshing works way better now.

-- If the content exists in the database, but not on the fileserver, it just deletes the content in the database instead of erroring out.

-- If content already exists on the file server, it will give an error saying the file might have been uploaded already instead of adding an empty content value in the database.